### PR TITLE
Release branch `unlifted-bool-1.1.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,42 @@
 # Revision history for unlifted-bool
 
-## 1.0.0 -- 2022-03-11
+## 0.1.1.1 -- 2022-08-22
 
-* First version. Released on an unsuspecting world.
+* Added module `Data.Bool.Unlifted.Core`, a core module defining the `Bool#` type.
+* Added instance `Lift Bool#`.
+* Added instance `Typeable Bool#`.
+* Added `toBool#`, a conversion from `Bool#` to `Bool`.
 
-## 1.1.0 -- 2022-06-05
+### Added `Bool#` Comparisons
+
+Added `eq#`, `ne#`, `lt#`, `le#`, `gt#`, and `ge#` comparisons for `Bool`.
+
+### Removed `Int#`, `Word#`, `Double#`, and `Float#` Comparisons 
+
+Removed all comparisons not relating to the `Bool#` type. These comparisons will be redefined in new packages specific to their types.
+
+### Name Changes
+* Renamed `fromBool` to `fromBool#`.
+* Renamed `andB#` to `and#`.
+* Renamed `orB#` to `or#`.
+* Renamed `xor#` to `xor#`.
+* Renamed `notB#` to `not#`.
+* Renamed `intToBool#` to `fromInt#`.
+* Renamed `boolToInt#` to `toInt#`.
+
+### Fixity Changes
+* Change fixity for logical `andB#` from `4` to `7`.
+* Change fixity for logical `orB#` from `4` to `5`.
+* Added fixity of `5` for logical `xorB#`.
+
+## 0.1.1.0 -- 2022-06-05
 
 * Removes the `Int#` comparisons `ltInt#`, `leInt#`, `eqInt#`, `neInt#`, `gtInt#`, and `geInt#`.
 * Removes the `Int8#` comparisons `ltInt8#`, `leInt8#`, `eqInt8#`, `neInt8#`, `gtInt8#`, and `geInt8#`.
 * Removes the `Int16#` comparisons `ltInt16#`, `leInt16#`, `eqInt16#`, `neInt16#`, `gtInt16#`, and `geInt16#`.
 * Removes the `Int32#` comparisons `ltInt32#`, `leInt32#`, `eqInt32#`, `neInt32#`, `gtInt32#`, and `geInt32#`.
+
+## 1.0.0 -- 2022-03-11
+
+* First version. Released on an unsuspecting world.
+

--- a/default.nix
+++ b/default.nix
@@ -1,44 +1,22 @@
-{ compiler ? "ghc921" }:
+{ ghc ? "ghc921" }:
 
 let
-  nixpkgs = builtins.fetchTarball {
-    # nixpkgs release 21.11
-    # url: <https://github.com/NixOS/nixpkgs/releases/tag/21.11>
-    url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.11.tar.gz";
-    sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
-  };
+  nixpkgs = import nix/nixpkgs.nix { };
 
-  config = { };
-
-  overlay = pkgsNew: pkgsOld: {
-    haskell = pkgsOld.haskell // {
-      packages = pkgsOld.haskell.packages // {
-        "${compiler}" = pkgsOld.haskell.packages."${compiler}".override (old: {
-          overrides = let
-            packageSources = pkgsNew.haskell.lib.packageSourceOverrides {
-              "unlifted-bool" = ./.;
-            };
-
-            manualOverrides = haskellPackagesNew: haskellPackagesOld: { };
-
-            default = old.overrides or (_: _: { });
-
-          in pkgsNew.lib.fold pkgsNew.lib.composeExtensions default [
-            packageSources
-            manualOverrides
-          ];
+  extension = pkgs: {
+    haskell = pkgs.haskell // {
+      packages = pkgs.haskell.packages // {
+        "${ghc}" = pkgs.haskell.packages."${ghc}".extend (self: _: {
+          unlifted-bool = self.callCabal2nix "unlifted-bool" ./. { };
         });
       };
     };
   };
 
   pkgs = import nixpkgs {
-    inherit config;
-    overlays = [ overlay ];
+    config.packageOverrides = extension;
   };
-
 in {
-  inherit (pkgs.haskell.packages."${compiler}") unlifted-bool;
-
-  shell = (pkgs.haskell.packages."${compiler}".unlifted-bool).env;
+  inherit (pkgs.haskell.packages."${ghc}") unlifted-bool; 
 }
+

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,4 @@
-{ ghc ? "ghc921" }:
+{ ghc ? "ghc922" }:
 
 let
   nixpkgs = import nix/nixpkgs.nix { };

--- a/hie.yaml
+++ b/hie.yaml
@@ -3,4 +3,8 @@ cradle:
     - path: "./src"
       component: "lib:unlifted-bool"
     # - path: "./test"
-    #   component: "test:bytevector"
+    #   component: "test:tests"
+
+dependencies:
+  - default.nix
+  - shell.nix

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -3,6 +3,6 @@
 # nixpkgs release 21.11 pinned on August 3rd, 2022.
 # url: <https://github.com/NixOS/nixpkgs/releases/tag/21.11>
 fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.11.tar.gz";
-  sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/22.05.tar.gz";
+  sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
 }

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+{ fetchTarball ? builtins.fetchTarball }:
+
+# nixpkgs release 21.11 pinned on August 3rd, 2022.
+# url: <https://github.com/NixOS/nixpkgs/releases/tag/21.11>
+fetchTarball {
+  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/21.11.tar.gz";
+  sha256 = "162dywda2dvfj1248afxc45kcrg83appjd0nmdb541hl7rnncf02";
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,1 @@
+(import ./default.nix { }).unlifted-bool

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,7 @@
-(import ./default.nix { }).shell
+{ ghc ? "ghc921" }:
+
+let 
+  pkgs = import ./default.nix { 
+    inherit ghc; 
+  };
+in pkgs.unlifted-bool.env

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ ghc ? "ghc921" }:
+{ ghc ? "ghc922" }:
 
 let 
   pkgs = import ./default.nix { 

--- a/src/Data/Bool/Unlifted/Core.hs
+++ b/src/Data/Bool/Unlifted/Core.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTSyntax #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE UnliftedNewtypes #-}
+{-# LANGUAGE TemplateHaskellQuotes #-}
+{-# OPTIONS_HADDOCK show-extensions #-}
+
+-- |
+-- Module      :  Data.Bool.Unlifted.Core
+-- Copyright   :  (c) Jacob Leach, 2022
+-- License     :  see LICENSE
+--
+-- Maintainer  :  jacobleach@protonmail.com
+-- Stability   :  stable
+-- Portability :  non-portable (GHC extensions)
+--
+-- TODO
+--
+-- @since 1.0.0
+module Data.Bool.Unlifted.Core
+  ( -- * TODO
+    Bool# (B#, False#, True#),
+  )
+where
+
+import Data.Typeable (Typeable)
+
+import GHC.Prim (Int#)
+
+--------------------------------------------------------------------------------
+
+import Data.Bool.Unlifted.Rep (BoolType)
+
+import GHC.Int (Int (I#))
+
+import Language.Haskell.TH (Exp (AppE, ConE, LitE), Lit (IntPrimL))
+import Language.Haskell.TH.Syntax (Lift (lift, liftTyped), unsafeCodeCoerce)
+
+--------------------------------------------------------------------------------
+
+-- | Unlifted boolean type, analogous to 'Bool'. A value of @Bool#@ represents 
+-- an @Int#@ that is either 0# for 'False' or 1# for 'True'.
+--
+-- @since 1.0.0
+newtype Bool# :: BoolType where
+  B# :: Int# -> Bool#
+  deriving Typeable
+
+{-# COMPLETE True#, False# #-}
+
+-- @since 1.0.0
+instance Lift Bool# where
+  lift (B# x) = pure (AppE (ConE 'B#) (LitE (IntPrimL (fromIntegral (I# x)))))
+  {-# INLINE CONLIKE lift #-}
+
+  liftTyped x = unsafeCodeCoerce (lift x)
+  {-# INLINE CONLIKE liftTyped #-}
+
+-- | Unlifted 'True' pattern synonym.
+--
+-- @since 1.0.0
+pattern True# :: Bool#
+pattern True# = B# 1#
+
+-- | Unlifted 'False' pattern synonym.
+--
+-- @since 1.0.0
+pattern False# :: Bool#
+pattern False# = B# 0#

--- a/src/Data/Bool/Unlifted/Rep.hs
+++ b/src/Data/Bool/Unlifted/Rep.hs
@@ -1,0 +1,51 @@
+-- |
+-- Module      :  Data.Bool.Unlifted.Rep
+-- Copyright   :  (c) Jacob Leach, 2022
+-- License     :  see LICENSE
+--
+-- Maintainer  :  jacobleach@protonmail.com
+-- Stability   :  stable
+-- Portability :  non-portable (GHC primitives)
+--
+-- "Data.Bool.Unlifted.Rep" exports the runtime representation and kind of the
+-- unlifted boolean type.
+--
+-- The runtime representation for unlifted boolean values 'BoolRep' is a synonym
+-- for 'IntRep' since GHC's prim-ops store boolean results as @Int#@ values:
+--
+-- @
+-- -- only the integer 1 is interpreted as 'True'
+-- 'GHC.Int.I#' (1# 'GHC.Prim.==#' 1#) == 1
+--
+-- -- any other integer is interpreted as 'False'
+-- 'GHC.Int.I#' (1# 'GHC.Prim.==#' 0#) == 0
+-- @
+--
+-- Choosing to represent unlifted boolean values as 'IntRep' means no additional
+-- overhead is incurred by using unlifted booleans over @Int#@. Choosing a
+-- different representation for 'BoolRep' with only two inhabitants (such as a
+-- pair of empty 'GHC.Types.TupleRep') is, in general, safer than 'IntRep'.
+-- However, a sum representation's incompatibility with GHC's prim-ops
+-- necessitates conversions to and from @Int#@ that can't be simplified away.
+--
+-- @since 1.0.0
+module Data.Bool.Unlifted.Rep
+  ( BoolType,
+    BoolRep,
+  )
+where
+
+import GHC.Types (RuntimeRep (IntRep), TYPE)
+
+--------------------------------------------------------------------------------
+
+-- | The kind of types that represent unlifted boolean values.
+--
+-- @since 1.0.0
+type BoolType = TYPE BoolRep
+
+-- | The runtime representation of unlifted boolean types.
+--
+--
+-- @since 1.0.0
+type BoolRep = 'IntRep

--- a/unlifted-bool.cabal
+++ b/unlifted-bool.cabal
@@ -2,7 +2,7 @@ cabal-version: 2.4
 
 name:         unlifted-bool
 category:     Data
-version:      0.1.1.0
+version:      1.1.1
 synopsis:     An unlifted boolean type.
 description:  An unlifted boolean type with safe pattern matching.
 license:      BSD-3-Clause
@@ -19,6 +19,7 @@ extra-source-files:
 
 tested-with:
   GHC == 9.2.1
+  GHC == 9.2.2
 
 common common
   default-language: Haskell2010
@@ -44,9 +45,12 @@ library
 
   exposed-modules:
     Data.Bool.Unlifted
+    Data.Bool.Unlifted.Rep
+    Data.Bool.Unlifted.Core
 
   build-depends:
     , ghc-prim
+    , template-haskell == 2.18.0.0
 
 source-repository head
   type:     git


### PR DESCRIPTION
Release branch tracking changes for version `1.1.1` of `unlifted-bool`.

- [X] Add `haskell-language-server` support.
- [X] Add editor config files.

### Changes to Nix

- [X] Remove redundant and unused variables in `default.nix`.
- [X] Replace `packageSourceOverrides` and `nixpkgs` overlay with `haskellPackages.extend`.
- [X] Remove the `shell` attribute from `default.nix` and simplify `shell.nix`.
- [X] Include a `release.nix` file.

### Changes to `library: unlifted-bool`

- [X] Add a new core module `Data.Bool.Unlifted.Core` for the `Bool#` type.
- [X] Standardize function naming convention.
  - [X] Rename conversion pairs as `fromX :: X -> Bool#` and `toX :: Bool# -> X`. For example: `fromInt# :: Int# -> Bool#` and `toInt# :: Bool# -> Int#`.
  - [X] Rename unlifted boolean operations by removing the `B` suffix. For example: rename `andB#` to `and#`.
- [X] Split comparisons (such as `eq#`, `lt#`, and etc..) to (new) individual `unlifted-*` packages.
- [X] Change `@since` annotation version from `X.X.X.X` to `X.X.X`.
